### PR TITLE
Fix the function of show more notifications

### DIFF
--- a/backend/core/api/base/notifications.py
+++ b/backend/core/api/base/notifications.py
@@ -36,6 +36,4 @@ def delete_notification(request: HtmxHttpRequest, id: int):
 
     notif.delete()
 
-    response = HttpResponse(status=200)
-    response["HX-Trigger"] = "refresh_notification_count"
-    return response
+    return get_notification_html(request)

--- a/frontend/templates/base/topbar/_notification_dropdown_items.html
+++ b/frontend/templates/base/topbar/_notification_dropdown_items.html
@@ -51,8 +51,8 @@
                 </a>
                 <button class="btn btn-outline btn-square btn-sm btn-error mt-1"
                         hx-delete="/api/base/notifications/delete/{{ notification.id }}"
-                        hx-target="closest li"
-                        hx-swap="outerHTML">
+                        hx-target="ul[data-notifications='container']"
+                        hx-swap="innerHTML">
                     <i class="fa fa-trash"></i>
                 </button>
             </div>


### PR DESCRIPTION
## Description

Fix the function of show more notification. Now every time a target notification is deleted, if the cumulative number of notifications is greater than 5 then the display list will always show the 5 most recent notifications.  


# Checklist

- [ ] Ran the [Black Formatter](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) and
  [djLint-er](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) on any new code
  (checks
  will
  fail without)
- [ ] Made any changes or additions to the documentation _where required_
- [ ] Changes generate no new warnings/errors
- [ ] New and existing [unit tests](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) pass locally with my
  changes


## What type of PR is this?
<!-- delete all that don't apply -->
- 🐛 Bug Fix

<!-- (optionally add your own bullet points) -->

## Added/updated tests?
<!-- delete all that don't apply -->
- 🙅 no, because they aren't needed


## Related PRs, Issues etc
- Related Issue https://github.com/zybgood/MyFinances/issues/9
